### PR TITLE
add generational fast path peer metadata APIs

### DIFF
--- a/crates/aptos-inspection-service/src/server/peer_information.rs
+++ b/crates/aptos-inspection-service/src/server/peer_information.rs
@@ -47,7 +47,7 @@ fn get_peer_information(
         peers_and_metadata.get_registered_networks().collect();
 
     // Get all peers (sorted by peer ID)
-    let mut all_peers = peers_and_metadata.get_all_peers().unwrap_or_default();
+    let mut all_peers = peers_and_metadata.get_all_peers();
     all_peers.sort();
 
     // Display a summary of all peers and networks

--- a/network/framework/src/application/storage.rs
+++ b/network/framework/src/application/storage.rs
@@ -76,7 +76,7 @@ impl PeersAndMetadata {
     /// Returns all peers. Note: this will return disconnected and unhealthy peers, so
     /// it is not recommended for applications to use this interface. Instead,
     /// `get_connected_peers_and_metadata()` should be used.
-    pub fn get_all_peers(&self) -> Result<Vec<PeerNetworkId>, Error> {
+    pub fn get_all_peers(&self) -> Vec<PeerNetworkId> {
         // Get the cached peers and metadata
         let cached_peers_and_metadata = self.cached_peers_and_metadata.load();
 
@@ -88,7 +88,7 @@ impl PeersAndMetadata {
                 all_peers.push(peer_network_id);
             }
         }
-        Ok(all_peers)
+        all_peers
     }
 
     /// Returns metadata for all peers currently connected to the node

--- a/network/framework/src/application/tests.rs
+++ b/network/framework/src/application/tests.rs
@@ -846,7 +846,7 @@ fn check_registered_networks(
 
 /// Verifies that all returned peers are correct
 fn check_all_peers(peers_and_metadata: &Arc<PeersAndMetadata>, expected_peers: Vec<PeerNetworkId>) {
-    let all_peers = peers_and_metadata.get_all_peers().unwrap();
+    let all_peers = peers_and_metadata.get_all_peers();
     compare_vectors_ignore_order(all_peers, expected_peers);
 }
 

--- a/peer-monitoring-service/client/src/lib.rs
+++ b/peer-monitoring-service/client/src/lib.rs
@@ -227,16 +227,7 @@ pub(crate) fn spawn_peer_metadata_updater(
             metadata_update_loop_ticker.next().await;
 
             // Get all peers
-            let all_peers = match peers_and_metadata.get_all_peers() {
-                Ok(all_peers) => all_peers,
-                Err(error) => {
-                    warn!(LogSchema::new(LogEntry::MetadataUpdateLoop)
-                        .event(LogEvent::UnexpectedErrorEncountered)
-                        .error(&error.into())
-                        .message("Failed to get all peers!"));
-                    continue; // Move to the next loop iteration
-                },
-            };
+            let all_peers = peers_and_metadata.get_all_peers();
 
             // Update the latest peer monitoring metadata
             for peer_network_id in all_peers {

--- a/peer-monitoring-service/client/src/tests/multiple_peers.rs
+++ b/peer-monitoring-service/client/src/tests/multiple_peers.rs
@@ -42,7 +42,7 @@ async fn test_peer_updater_loop_multiple_peers() {
 
     // Verify peers and metadata is empty
     let peers_and_metadata = peer_monitoring_client.get_peers_and_metadata();
-    assert!(peers_and_metadata.get_all_peers().unwrap().is_empty());
+    assert!(peers_and_metadata.get_all_peers().is_empty());
 
     // Add a connected validator peer
     let validator_peer =

--- a/peer-monitoring-service/client/src/tests/single_peer.rs
+++ b/peer-monitoring-service/client/src/tests/single_peer.rs
@@ -128,7 +128,7 @@ async fn test_basic_peer_updater_loop() {
 
     // Verify peers and metadata is empty
     let peers_and_metadata = peer_monitoring_client.get_peers_and_metadata();
-    assert!(peers_and_metadata.get_all_peers().unwrap().is_empty());
+    assert!(peers_and_metadata.get_all_peers().is_empty());
 
     // Add a connected fullnode peer
     let fullnode_peer = mock_monitoring_server.add_new_peer(NetworkId::Public, PeerRole::Unknown);


### PR DESCRIPTION
### Description
Add 'generational' APIs to PeersAndMetadata to have a fast-no-op get when data hasn't changed.

This branch should retarget to `main` after https://github.com/aptos-labs/aptos-core/pull/12608 merges

### Test Plan
Includes new unit test. Is used by forthcoming network2 branch.
